### PR TITLE
Duplicate items appeared when scrolling to bottom of feed

### DIFF
--- a/js/qvitter.js
+++ b/js/qvitter.js
@@ -1051,7 +1051,7 @@ $(window).scroll(function() {
 				}
 			// normal streams
 			else {
-				var getVars = qOrAmp(window.currentStream) + 'max_id=' + $('#feed-body').children('.stream-item').last().attr('data-quitter-id-in-stream');				
+				var getVars = qOrAmp(window.currentStream) + 'max_id=' + ($('#feed-body').children('.stream-item').last().attr('data-quitter-id-in-stream')-1);
 				}
 			
 			display_spinner('#footer-spinner-container');		


### PR DESCRIPTION
At least on the "notifications" feed page many users on quitter.es reported
that their notifications were duplicated when scrolling down.

It appears that qvitter.js fetches notices but does not check which notices
were already there, so I did a quick fix and set the feed to only fetch
notices which had a max_id of the last item _minus one_.

max_id is inclusive in GNU social.