### PR TITLE
Generate thumbnail if it doesn't exist

### DIFF
--- a/QvitterPlugin.php
+++ b/QvitterPlugin.php
@@ -484,11 +484,9 @@ class QvitterPlugin extends Plugin {
             foreach ($attachments as $attachment) {
                 try {
                     $enclosure_o = $attachment->getEnclosure();
-	                $thumb = File_thumbnail::getKV('file_id', $attachment->id);    	                
-                    if(isset($thumb->url)) {
-	                    $attachment_url_to_id[$enclosure_o->url]['id'] = $attachment->id;
-	                    $attachment_url_to_id[$enclosure_o->url]['thumb_url'] = $thumb->url;
-	                    }                    
+	                $thumb = $attachment->getThumbnail();
+	                $attachment_url_to_id[$enclosure_o->url]['id'] = $attachment->id;
+	                $attachment_url_to_id[$enclosure_o->url]['thumb_url'] = $thumb->getUrl();
                 } catch (ServerException $e) {
                     // There was not enough metadata available
                 }


### PR DESCRIPTION
This will call getThumbnail() on the File object so a thumbnail is actually generated (and cached for later) if it was missing. The previous code would only fetch pre-generated thumbnails, meaning that in most cases you'd have to view the attachment page or otherwise semi-manually visit an attachment page before a thumbnail would appear.

With latest GNU social nightly code the getThumbnail code (using the Oembed plugin) will also fetch thumbnails from trusted remote sources (currently i*.ytimg.com) and host them locally. That means we won't have a problem with hotlinking (YouTube) http from https.