### PR TITLE
EndSetApiUser is not always a User

### DIFF
--- a/QvitterPlugin.php
+++ b/QvitterPlugin.php
@@ -806,6 +806,9 @@ class QvitterPlugin extends Plugin {
      * @return boolean hook flag
      */        
     public function onEndSetApiUser($user) {
+        if (!$user instanceof User) {
+            return true;
+        }
 
 		$user_id = $user->id;
 		$notification = new QvitterNotification();


### PR DESCRIPTION
GNU social will however make sure that whenever the event is called, User
_has_ been set, but for anyone not stalking the nightly branch they will
have less messages like this in their PHP error log:

PHP Notice:  Trying to get property of non-object in [...]/Qvitter/QvitterPlugin.php on line 810