### PR TITLE
Added equal to the query in NotificationStream. Related to issue #116

### DIFF
--- a/classes/NotificationStream.php
+++ b/classes/NotificationStream.php
@@ -37,7 +37,7 @@ class NotificationStream
         $notification->selectAdd();
         $notification->selectAdd('id');
         $notification->whereAdd(sprintf('qvitternotification.to_profile_id = "%s"', $notification->escape($this->target->id)));
-        $notification->whereAdd(sprintf('qvitternotification.created > "%s"', $notification->escape($this->target->created)));
+        $notification->whereAdd(sprintf('qvitternotification.created >= "%s"', $notification->escape($this->target->created)));
         $notification->limit($offset, $limit);
         $notification->orderBy('qvitternotification.created DESC');
 


### PR DESCRIPTION
Added a equal sign to this query : 
$notification->whereAdd(sprintf('qvitternotification.created >= "%s"', $notification->escape($this->target->created)));

If the user is newly created and the instance is using greeting (welcome config), the notification does not dissapear because the notification creation datetime is not "greater than" in the where clause.
Added a equal sign returns the only row which is inserted in the qvitternotification table for that user.
Tested on a local instance.