### PR TITLE
$.inArray(...) was always evaluated as true

### DIFF
--- a/js/dom-functions.js
+++ b/js/dom-functions.js
@@ -945,7 +945,7 @@ function expand_queet(q,doScrolling) {
 				// attachments in the content link to /attachment/etc url and not direct to image/video, link is in title
 				if(typeof attachment_title != 'undefined') {
 					// images
-					if($.inArray(attachment_mimetype, ['image/gif', 'image/jpeg', 'image/png'])) {
+					if($.inArray(attachment_mimetype, ['image/gif', 'image/jpeg', 'image/png']) >= 0) {
 						if(q.children('.queet').find('.expanded-content').children('.media').children('a[href="' + attachment_title + '"]').length < 1) { // not if already showed
 							
 							// local attachment with a thumbnail


### PR DESCRIPTION
>= 0 because index entries start at 0 (if not found, inArray returns -1)