### PR TITLE
max-width 100% for img and video media

### DIFF
--- a/css/qvitter.css
+++ b/css/qvitter.css
@@ -2191,7 +2191,7 @@ ul.queet-actions li .icon.is-mine:before {
 	}
 .stream-item .media img,
 .stream-item .media video {
-    max-width: 500px;
+    max-width: 100%;
 	}
 
 ul.stats {


### PR DESCRIPTION
There's still a margin to the edges, but this will make it scale properly
in the smaller width mobile-mode as well, without a bunch of @media rules.