### PR TITLE
make sure the status array has 'repeated' key

### DIFF
--- a/QvitterPlugin.php
+++ b/QvitterPlugin.php
@@ -481,7 +481,7 @@ class QvitterPlugin extends Plugin {
 		$twitter_status['statusnet_in_groups'] = $group_addressees;    
 
 		// include the repeat-id, which we need when unrepeating later
-		if($twitter_status['repeated'] === true) {
+		if(array_key_exists('repeated', $twitter_status) && $twitter_status['repeated'] === true) {
 			$repeated = Notice::pkeyGet(array('profile_id' => $scoped->id,
                                         	'repeat_of' => $notice->id));
 			$twitter_status['repeated_id'] = $repeated->id;


### PR DESCRIPTION
I think the event handler should be doublechecked on more than one
point. For example the call arguments don't seem to include an array
argument which can include an option called "include_user". Also the
$scoped value is not necessarily always a Profile, it can be null too.

The reason I'm making this is because the 'repeated' value is set in a plugin in nightly GNU social. The upside there is that the plugin ("Share") also sets the "repeated_id" value used by Qvitter - so no information is lost even if this if statement would return false (in the case of running latest GNU social).