### PR TITLE
Mention fixing

### DIFF
--- a/QvitterPlugin.php
+++ b/QvitterPlugin.php
@@ -705,8 +705,8 @@ class QvitterPlugin extends Plugin {
 				//} catch (NoParentNoticeException $e) {	// TODO: catch this when everyone runs latest GNU social!
 					// This is not a reply to something (has no parent)
 				} catch (NoResultException $e) {
-					// Parent notice or its author's profile not found! Complain louder?
-					common_log(LOG_ERR, 'NoResultException: '.$e->getMessage());
+					// Parent author's profile not found! Complain louder?
+					common_log(LOG_ERR, "Parent notice's author not found: ".$e->getMessage());
 				}
 			}
 

--- a/QvitterPlugin.php
+++ b/QvitterPlugin.php
@@ -698,13 +698,17 @@ class QvitterPlugin extends Plugin {
 	 		$reply_notification_to = false; 		
 			// check for reply to insert in notifications
 			if($notice->reply_to) {
-				$replyparent = $notice->getParent();
-				$replyauthor = $replyparent->getProfile();
-				if ($replyauthor instanceof Profile) {
+				try {
+					$replyauthor = $notice->getParent()->getProfile();
 					$reply_notification_to = $replyauthor->id;
 					$this->insertNotification($replyauthor->id, $notice->profile_id, 'reply', $notice->id);
-					}
+				//} catch (NoParentNoticeException $e) {	// TODO: catch this when everyone runs latest GNU social!
+					// This is not a reply to something (has no parent)
+				} catch (NoResultException $e) {
+					// Parent notice or its author's profile not found! Complain louder?
+					common_log(LOG_ERR, 'NoResultException: '.$e->getMessage());
 				}
+			}
 
 			// check for mentions to insert in notifications
 			$mentions = common_find_mentions($notice->content, $notice);

--- a/QvitterPlugin.php
+++ b/QvitterPlugin.php
@@ -663,6 +663,7 @@ class QvitterPlugin extends Plugin {
      * @return boolean hook flag
      */
     function onStartNoticeDistribute($notice) {
+        assert($notice->id > 0);    // since we removed tests below
 
 		// don't add notifications for activity type notices
 		if($notice->object_type == 'activity') {
@@ -699,7 +700,7 @@ class QvitterPlugin extends Plugin {
 			if($notice->reply_to) {
 				$replyparent = $notice->getParent();
 				$replyauthor = $replyparent->getProfile();
-				if ($replyauthor instanceof Profile && !empty($notice->id)) {
+				if ($replyauthor instanceof Profile) {
 					$reply_notification_to = $replyauthor->id;
 					$this->insertNotification($replyauthor->id, $notice->profile_id, 'reply', $notice->id);
 					}
@@ -719,7 +720,7 @@ class QvitterPlugin extends Plugin {
 					$all_mentioned_user_ids[] = $mentioned->id;
 				
 					// only notify if mentioned user is not already notified for reply
-					if($reply_notification_to != $mentioned->id && !empty($notice->id)) {
+					if($reply_notification_to != $mentioned->id) {
 						$this->insertNotification($mentioned->id, $notice->profile_id, 'mention', $notice->id);                	
 						}
 					}


### PR DESCRIPTION
This doesn't actually do anything, but it removes some lines of code and uses exceptions instead of if statements to test some stuff in onStartNoticeDistribute

What I actually want to do is remove the common_find_mentions thing, but it would take a little bit of more work than I thought at first. So to avoid feeling totally lame and unproductive I send you this pull request.

Feel free to decline it.