### PR TITLE
No need to check logged in user

### DIFF
--- a/QvitterPlugin.php
+++ b/QvitterPlugin.php
@@ -588,10 +588,9 @@ class QvitterPlugin extends Plugin {
 		// mark reply/mention-notifications as read if we're replying to a notice we're notified about
 		if($notice->reply_to) {
 
-			$user = common_current_user();
             $notification_to_mark_as_seen = QvitterNotification::pkeyGet(array('is_seen' => 0,
                                                                                 'notice_id' => $notice->reply_to,
-                                                                                'to_profile_id' => $user->id));
+                                                                                'to_profile_id' => $notice->profile_id));
             if($notification_to_mark_as_seen instanceof QvitterNotification
             && ($notification_to_mark_as_seen->ntype == 'mention' || $notification_to_mark_as_seen->ntype == 'reply')) {
                 $orig = clone($notification_to_mark_as_seen);


### PR DESCRIPTION
It's always the notice's author we want to check this for anyway.

I kept getting errors like, which are now fixed:
   Trying to get property of non-object in /srv/www/vhosts/se/umeahackerspace/social/%/htdocs/local/plugins/Qvitter/QvitterPlugin.php on line 594

I guess it might also screw up (somehow?) if some future awesome
notice handling thing decided to run the StartNoticeDistribute event
when the session is not currently used by the notice's author. But
that's a bit far-fetched.