### PR TITLE
Make handling deleted notices an option

### DIFF
--- a/QvitterPlugin.php
+++ b/QvitterPlugin.php
@@ -41,6 +41,8 @@ class QvitterPlugin extends Plugin {
     protected $hijack_ui = true;
     protected $qvitter_hide_replies = false;
 
+    public $handleDeletedNotices = true;
+
 	static function settings($setting)
 	{
 
@@ -713,6 +715,9 @@ class QvitterPlugin extends Plugin {
      */
     public function onNoticeDeleteRelated($notice)
     {
+        if (!$this->handleDeletedNotices) {
+            return true;
+        }
 
 		$notif = new QvitterNotification();
 
@@ -766,7 +771,7 @@ class QvitterPlugin extends Plugin {
 
     public function onEndHandleFeedEntry($activity) {
 
-		if($activity->verb == 'qvitter-delete-notice') {
+		if($activity->verb == 'qvitter-delete-notice' && $this->handleDeletedNotices) {
 
 			$deleter_profile_uri = $activity->actor->id;
 			$deleted_notice_uri = $activity->objects[0]->objects[0]->content;


### PR DESCRIPTION
This should be handled by core, so I add this as an option in order
to be able to disable on instances where GNU social does this based
on ActivityStreams standards.

Pass an array with the setting in config.php to explicitly enable/disable (default is to let Qvitter handle deleted notices its own way, possibly in parallell with GNU social), like this:

addPlugin('Qvitter', array('handleDeletedNotices' => false));