### PR TITLE
get rid of some PHP Strict Standards warnings

### DIFF
--- a/actions/apiqvitterchecklogin.php
+++ b/actions/apiqvitterchecklogin.php
@@ -57,9 +57,9 @@ class ApiQvitterCheckLoginAction extends ApiAction
      *
      * @return void
      */
-    function handle($args)
+    protected function handle()
     {
-        parent::handle($args);
+        parent::handle();
 
         if ($_SERVER['REQUEST_METHOD'] != 'POST') {
             $this->clientError(

--- a/actions/apitimelinepublicandexternal.php
+++ b/actions/apitimelinepublicandexternal.php
@@ -65,7 +65,7 @@ class ApiTimelinePublicAndExternalAction extends ApiPrivateAuthAction
      * @return boolean success flag
      *
      */
-    function prepare($args)
+    protected function prepare(array $args=array())
     {
         parent::prepare($args);
 
@@ -79,13 +79,11 @@ class ApiTimelinePublicAndExternalAction extends ApiPrivateAuthAction
      *
      * Just show the notices
      *
-     * @param array $args $_REQUEST data (unused)
-     *
      * @return void
      */
-    function handle($args)
+    protected function handle()
     {
-        parent::handle($args);
+        parent::handle();
         $this->showTimeline();
     }
 


### PR DESCRIPTION
The function declarations did not match the parent class.

I just want to get rid of everything from my php-error.log