### PR TITLE
Show notice content to search engines and scrapers

### DIFF
--- a/actions/qvitter.php
+++ b/actions/qvitter.php
@@ -521,7 +521,16 @@ class QvitterAction extends ApiAction
 							</div>
 						</div>
 						<div id="new-queets-bar-container" class="hidden"><div id="new-queets-bar"></div></div>
-						<div id="feed-body"></div>
+						<div id="feed-body"><?php
+							if($this->arg('notice')) {
+								echo '<ol class="notices xoxo">';
+								$notice = Notice::getKV('id', $this->arg('notice'));
+								$widget = new NoticeListItem($notice, $this);
+								$widget->show();
+								$this->flush();
+								echo '</ol>';
+							}
+						?></div>
 					</div>
 
 					<div id="footer"><div id="footer-spinner-container"></div></div>


### PR DESCRIPTION
This is needed for pingback and webmention to work properly
and should improve search engine results, etc.

Re-use the mainline notice show code to get all the microformats goodness, etc.