### PR TITLE
Only enable qvitter for javascript users

### DIFF
--- a/QvitterPlugin.php
+++ b/QvitterPlugin.php
@@ -129,22 +129,6 @@ class QvitterPlugin extends Plugin {
     {
         // show qvitter link in the admin panel
         common_config_append('admin', 'panels', 'qvitteradm');
-
-        if (common_logged_in()) {
-            $qvitter_enabled = static::settings('enabledbydefault') ? 'true' : 'false';
-            if ($qvitter_enabled === 'true') {
-                // if qvitter is enabled by default but _not_ disabled by the user,
-                if (Profile::current()->getConfigPref('qvitter', 'disable_qvitter') == 0) {
-                    $qvitter_enabled = 'true';
-                }
-            } else {
-                // if qvitter is disabled by default and _enabled_ by the user,
-                if (Profile::current()->getConfigPref('qvitter', 'enable_qvitter') == 1) {;
-                    $qvitter_enabled = 'true';
-                }
-            }
-            common_set_cookie('qvitter:enabled', $qvitter_enabled); // remember this to avoid javascript redirect
-        }
     }
 
     // make sure we have a notifications table
@@ -248,6 +232,10 @@ class QvitterPlugin extends Plugin {
         // if we're logged in, and qvitter is _not_ enabled by default, reroute if the user enabled qvitter
         elseif(static::settings('enabledbydefault') === false && $qvitter_enabled_by_user == 1) {
             $this->hijack_ui = true;
+        }
+
+        if (common_logged_in()) {
+            common_set_cookie('qvitter:enabled', $this->hijack_ui?'true':'false'); // remember this to avoid javascript redirect
         }
 
 
@@ -405,12 +393,6 @@ class QvitterPlugin extends Plugin {
                                 ');
         $action->script($this->path('js/toggleqvitter.js').'?changed='.date('YmdHis',filemtime(QVITTERDIR.'/js/toggleqvitter.js')));
     }
-
-    function onEndLogout(ManagedAction $action) {
-        common_set_cookie('qvitter:enabled', '', time()-3600);
-    }
-
-
 
     /**
      * Menu item for Qvitter

--- a/actions/apitoggleqvitter.php
+++ b/actions/apitoggleqvitter.php
@@ -37,23 +37,8 @@
 
 if (!defined('GNUSOCIAL')) { exit(1); }
 
-class ApiToggleQvitterAction extends ApiAuthAction
+class ApiToggleQvitterAction extends ApiAction
 {
-
-    /**
-     * Take arguments for running
-     *
-     * @param array $args $_REQUEST args
-     *
-     * @return boolean success flag
-     */
-    protected function prepare(array $args=array())
-    {
-        parent::prepare($args);
-
-        return true;
-    }
-
     /**
      * Handle the request
      *
@@ -64,6 +49,15 @@ class ApiToggleQvitterAction extends ApiAuthAction
     protected function handle()
     {
         parent::handle();
+
+        if (!common_logged_in()) {
+            $state = isset($_COOKIE['qvitter:enabled'])
+                            ? $_COOKIE['qvitter:enabled'] === 'true'
+                            : false;
+            // switch states
+            common_set_cookie('qvitter:enabled', (!$state ? 'true' : 'false'));
+            $result['success'] = true;
+        } else {
 
         $user = common_current_user();
 		$profile = $user->getProfile();
@@ -94,6 +88,7 @@ class ApiToggleQvitterAction extends ApiAuthAction
         if(!$pref_saved) {
             $result['success'] = false;
             $result['error'] = 'Probably couldn\'t get topic from pref table';            
+        }
         }
 
         $this->initDocument('json');

--- a/js/toggleqvitter.js
+++ b/js/toggleqvitter.js
@@ -41,19 +41,26 @@
    · · · · · · · · · · · · · */
 
 
-if(qvitterEnabled) {
-	$('#site_nav_global_primary').find('.nav').first().prepend('<li id="toggleqvitter" title="' + toggleText + '"><a href="' + qvitterAllLink + '">' + toggleText + '</a></li>');
-	}
-else {
-	$('#site_nav_global_primary').find('.nav').first().prepend('<li id="toggleqvitter" title="' + toggleText + '"><a href="' + location.href + '">' + toggleText + '</a></li>');
+if ($.cookie('qvitter:enabled') === undefined && qvitterEnabledByDefault) {
+    if (qvitterEnabledByDefault) {
+        $.cookie('qvitter:enabled', 'true');
+        location.reload(true);
+    } else {
+        $.cookie('qvitter:enabled', 'false');
+        // we are already in classic view!
+    }
+} else {
+    $('#site_nav_global_primary').find('.nav').first().prepend('<li id="toggleqvitter" title="' + toggleText + '"><a href="' + location.href + '">' + toggleText + '</a></li>');
 
-	$('#toggleqvitter > a').click(function(e){
-		e.preventDefault();
-		$.get(toggleQvitterAPIURL,function(data){
-			if(data.success === true) {
-				window.location.href = qvitterAllLink;
-				}
-			});
+    if ($.cookie('qvitter:enabled') === 'false') {
+        $('#toggleqvitter > a').click(function(e){
+            e.preventDefault();
+            $.get(toggleQvitterAPIURL,function(data){
+                if(data.success === true) {
+                    location.reload(true);
+                    }
+                });
 
-		});
-	}
+        });
+    }
+}

--- a/js/toggleqvitter.js
+++ b/js/toggleqvitter.js
@@ -52,15 +52,13 @@ if ($.cookie('qvitter:enabled') === undefined && qvitterEnabledByDefault) {
 } else {
     $('#site_nav_global_primary').find('.nav').first().prepend('<li id="toggleqvitter" title="' + toggleText + '"><a href="' + location.href + '">' + toggleText + '</a></li>');
 
-    if ($.cookie('qvitter:enabled') === 'false') {
-        $('#toggleqvitter > a').click(function(e){
-            e.preventDefault();
-            $.get(toggleQvitterAPIURL,function(data){
-                if(data.success === true) {
-                    location.reload(true);
-                    }
-                });
+    $('#toggleqvitter > a').click(function(e){
+        e.preventDefault();
+        $.get(toggleQvitterAPIURL,function(data){
+            if(data.success === true) {
+                location.reload(true);
+                }
+            });
 
-        });
-    }
+    });
 }


### PR DESCRIPTION
Also makes it less problematic that Qvitter doesn't provide <head/>
metadata everywhere.

The first time a non-logged in user loads the website, javascript will
run (or not) that sets a cookie to enable qvitter and reloads the page.

I also made it so that when Qvitter is enabled, it just reloads the same
page and doesn't go to your home timeline.