### PR TITLE
Avoid selecting profile suggestion if Ctrl+Enter is pressed

### DIFF
--- a/js/qvitter.js
+++ b/js/qvitter.js
@@ -2776,7 +2776,7 @@ $('body').on('keydown', '.queet-box-syntax', function(e) {
 	if($(this).siblings('.mentions-suggestions').children('div').length > 0) {
 
 		// enter or tab
-		if (e.keyCode == '13' || e.keyCode == '9') {
+		if (!e.ctrlKey && (e.keyCode == '13' || e.keyCode == '9')) {
 			e.preventDefault();
 			useSelectedMention($(this));
 			}


### PR DESCRIPTION
If I was typing a queet and ended with a mention (@theru) it listed
several nicknames matching '%theru%', such as 'anoTHERUser'. When I
sent the queet with the short command Ctrl+Enter it chose @anotheruser
and my friend theru was ever so sad not to receive the notification :(